### PR TITLE
Add week-starts-on-sunday? option to datepicker

### DIFF
--- a/src/examples/basic/datepicker_example.cljs
+++ b/src/examples/basic/datepicker_example.cljs
@@ -12,57 +12,74 @@
     (render-state [this state]
       (html
         [:div.panel.panel-default
-         [:div.panel-heading "Datepciker"]
+         [:div.panel-heading "Datepicker"]
          [:div.panel-body
           [:div.row
            [:div.col-lg-6
             [:div.well
              [:label "Input Group - left side"]
              (w/popover
-               (fn [show]
-                 [:div.input-group
-                  [:span.input-group-btn
-                   [:button.btn.btn-primary {:id "btn-cal-left" :onClick show}
-                    [:span.glyphicon.glyphicon-calendar]]]
-                  (w/textinput app :input-group-left {:input-class "form-control"
-                                                      :input-format "date"
-                                                      :placeholder "MM/DD/YYYY"})])
-               (fn [close]
-                 (w/datepicker app :input-group-left))
-               {:for "btn-cal-left"})]
+              (fn [show]
+                [:div.input-group
+                 [:span.input-group-btn
+                  [:button.btn.btn-primary {:id "btn-cal-left" :onClick show}
+                   [:span.glyphicon.glyphicon-calendar]]]
+                 (w/textinput app :input-group-left {:input-class "form-control"
+                                                     :input-format "date"
+                                                     :placeholder "MM/DD/YYYY"})])
+              (fn [close]
+                (w/datepicker app :input-group-left))
+              {:for "btn-cal-left"})]
 
             [:div.well
              [:label "Input Group - right side"]
              (w/popover
-               (fn [show]
-                 [:div.input-group
-                  (w/textinput app :input-group-right {:input-class "form-control"
-                                                       :input-format "date"
-                                                       :placeholder "MM/DD/YYYY"})
-                  [:span.input-group-btn
-                   [:button.btn.btn-primary {:id "btn-cal-right" :onClick show}
-                    [:span.glyphicon.glyphicon-calendar]]]])
-               (fn [close]
-                 (w/datepicker app :input-group-right))
-               {:for "btn-cal-right"})]
+              (fn [show]
+                [:div.input-group
+                 (w/textinput app :input-group-right {:input-class "form-control"
+                                                      :input-format "date"
+                                                      :placeholder "MM/DD/YYYY"})
+                 [:span.input-group-btn
+                  [:button.btn.btn-primary {:id "btn-cal-right" :onClick show}
+                   [:span.glyphicon.glyphicon-calendar]]]])
+              (fn [close]
+                (w/datepicker app :input-group-right))
+              {:for "btn-cal-right"})]
 
             [:div.well
              [:label "Input Group - Close when selecting day"]
              (w/popover
-               (fn [show]
-                 [:div.input-group
-                  (w/textinput app :input-group-close-on-change {:input-class "form-control"
-                                                                 :input-format "date"
-                                                                 :placeholder "MM/DD/YYYY"})
-                  [:span.input-group-btn
-                   [:button.btn.btn-primary {:id "btn-cal-close-on-select" :onClick show}
-                    [:span.glyphicon.glyphicon-calendar]]]])
-               (fn [close]
-                 (w/datepicker app :input-group-close-on-change {:onChange close}))
-               {:for "btn-cal-close-on-select"})]]
+              (fn [show]
+                [:div.input-group
+                 (w/textinput app :input-group-close-on-change {:input-class "form-control"
+                                                                :input-format "date"
+                                                                :placeholder "MM/DD/YYYY"})
+                 [:span.input-group-btn
+                  [:button.btn.btn-primary {:id "btn-cal-close-on-select" :onClick show}
+                   [:span.glyphicon.glyphicon-calendar]]]])
+              (fn [close]
+                (w/datepicker app :input-group-close-on-change {:onChange close}))
+              {:for "btn-cal-close-on-select"})]
+            [:div.well
+             [:label "Input Group - Close when selecting day - week starts on Sunday"]
+             (w/popover
+              (fn [show]
+                [:div.input-group
+                 (w/textinput app :input-group-close-on-change {:input-class "form-control"
+                                                                :input-format "date"
+                                                                :placeholder "MM/DD/YYYY"})
+                 [:span.input-group-btn
+                  [:button.btn.btn-primary {:id "btn-cal-close-on-select" :onClick show}
+                   [:span.glyphicon.glyphicon-calendar]]]])
+              (fn [close]
+                (w/datepicker app :input-group-close-on-change {:onChange close
+                                                                :week-starts-on-sunday? true}))
+              {:for "btn-cal-close-on-select"})]]
 
            [:div.col-lg-6
             [:div.well
              (w/datepicker app :inline)
-             ]
-            [:label (str (:inline app))]]]]]))))
+             (w/textinput app :inline {:read-only true :input-format "date"})]
+            [:div.well
+             (w/datepicker app :inline1 {:week-starts-on-sunday? true})
+             (w/textinput app :inline1 {:read-only true :input-format "date"})]]]]]))))

--- a/src/examples/basic/state_example.cljs
+++ b/src/examples/basic/state_example.cljs
@@ -70,6 +70,7 @@
                              :type :entry
                              :text "Logout"}]}]]
      :datepicker {:inline #inst "1991-01-25"
+                  :inline1 #inst "1991-01-25"
                   :input-group-left #inst "1991-01-25"
                   :input-group-right #inst "1991-01-25"
                   :input-group-close-on-change #inst "1991-01-25"}

--- a/src/om_widgets/datepicker.cljs
+++ b/src/om_widgets/datepicker.cljs
@@ -29,10 +29,13 @@
                                 (- last-day (dec weekday-current-month))
                                 (inc (- last-day (dec weekday-current-month))))
         days-to-fill          (range lower-bound (inc last-day))]
-    (mapv (fn [d] {:day              d
-                   :month            (- 1 (time/month date))
-                   :year             (time/year date)
-                   :belongs-to-month :previous}) days-to-fill)))
+    (if (= 7 (count days-to-fill))
+      nil
+      
+      (mapv (fn [d] {:day              d
+                     :month            (- 1 (time/month date))
+                     :year             (time/year date)
+                     :belongs-to-month :previous}) days-to-fill))))
 
 (defn- build-current-month-days [date]
   (let [last-day (time/number-of-days-in-the-month date)]
@@ -43,16 +46,24 @@
              :belongs-to-month :current})
           (range 1 (inc last-day)))))
 
-(defn- build-next-month-days [date]
+(defn- build-next-month-days
+  [date & {:keys [week-starts-on-sunday?]
+           :or {week-starts-on-sunday? false}}]
   (let [current-month (time/date-time (time/year date) (time/month date))
         last-day-number (time/number-of-days-in-the-month current-month)
         last-day (time/date-time (time/year current-month) (time/month current-month) last-day-number)
         weekday-last-day (time/day-of-week last-day)
-        days-to-fill (range 1 (inc (- 14 weekday-last-day)))]
-    (mapv (fn [d] {:day d
-                   :month (+ 1 (time/month date))
-                   :year (time/year date)
-                   :belongs-to-month :next}) days-to-fill)))
+        days-to-fill (range 1 
+                            (if week-starts-on-sunday?
+                              (- 14 weekday-last-day)
+                              (inc (- 14 weekday-last-day))))]
+    (->> days-to-fill
+         (mapv (fn [d] {:day d
+                        :month (+ 1 (time/month date))
+                        :year (time/year date)
+                        :belongs-to-month :next}))
+         (take (mod (count days-to-fill) 7))
+         (into []))))
 
 (defn- build-weeks
   "We build a 7x6 matrix representing the 7 days in a week and
@@ -72,7 +83,7 @@
            :or {week-starts-on-sunday? false}}]
   (let [previous-days (build-previous-month-days date :week-starts-on-sunday? week-starts-on-sunday?)
         currrent-days (build-current-month-days date)
-        next-days (build-next-month-days date)
+        next-days (build-next-month-days date :week-starts-on-sunday? week-starts-on-sunday?)
         days (into [] (concat previous-days currrent-days next-days))]
     (take 6 (mapv vec (partition 7 days)))))
 
@@ -148,8 +159,7 @@
                               (time/days (time/day-of-week date)))]
     (map #(time/plus start-day
                      (time/days %))
-        ;;  (range 1 8)
-         (range 8))))
+         (range 1 8))))
 
 (defn current-week
   "Returns a list of days for the current week"

--- a/src/om_widgets/datepicker.cljs
+++ b/src/om_widgets/datepicker.cljs
@@ -7,7 +7,7 @@
             [cljs-time.coerce :as timec]))
 
 ;; TODO translate
-(defonce days-short ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"])
+(defonce days-short ["Mo" "Tu" "We" "Th" "Fr" "Sa" "Su"])
 
 (defn weekday-labels
   "Returns the short labels for the days of the week.
@@ -18,15 +18,20 @@
     (concat ["Su"] (butlast days-short))
     days-short))
 
-(defn- build-previous-month-days [date]
-  (let [current-month (time/date-time (time/year date) (time/month date))
+(defn- build-previous-month-days
+  [date & {:keys [week-starts-on-sunday?]
+           :or   {week-starts-on-sunday? false}}]
+  (let [current-month         (time/date-time (time/year date) (time/month date))
         weekday-current-month (time/day-of-week current-month)
-        previous-month (time/minus current-month (time/months 1))
-        last-day (time/number-of-days-in-the-month previous-month)
-        days-to-fill (range (inc (- last-day (dec weekday-current-month))) (inc last-day))]
-    (mapv (fn [d] {:day d
-                   :month (- 1 (time/month date))
-                   :year (time/year date)
+        previous-month        (time/minus current-month (time/months 1))
+        last-day              (time/number-of-days-in-the-month previous-month)
+        lower-bound           (if week-starts-on-sunday?
+                                (- last-day (dec weekday-current-month))
+                                (inc (- last-day (dec weekday-current-month))))
+        days-to-fill          (range lower-bound (inc last-day))]
+    (mapv (fn [d] {:day              d
+                   :month            (- 1 (time/month date))
+                   :year             (time/year date)
                    :belongs-to-month :previous}) days-to-fill)))
 
 (defn- build-current-month-days [date]
@@ -43,7 +48,6 @@
         last-day-number (time/number-of-days-in-the-month current-month)
         last-day (time/date-time (time/year current-month) (time/month current-month) last-day-number)
         weekday-last-day (time/day-of-week last-day)
-        weekday-current-month (time/day-of-week current-month)
         days-to-fill (range 1 (inc (- 14 weekday-last-day)))]
     (mapv (fn [d] {:day d
                    :month (+ 1 (time/month date))
@@ -66,7 +70,7 @@
   "
   [date & {:keys [week-starts-on-sunday?]
            :or {week-starts-on-sunday? false}}]
-  (let [previous-days (build-previous-month-days date)
+  (let [previous-days (build-previous-month-days date :week-starts-on-sunday? week-starts-on-sunday?)
         currrent-days (build-current-month-days date)
         next-days (build-next-month-days date)
         days (into [] (concat previous-days currrent-days next-days))]
@@ -76,8 +80,9 @@
   (om/component
    (dom/th #js {:className "dow"} day)))
 
-(defmulti get-date-from-selected-day (fn [previous-date selected-day]
-                                       (:belongs-to-month selected-day)))
+(defmulti get-date-from-selected-day
+  (fn [previous-date selected-day]
+    (:belongs-to-month selected-day)))
 
 (defmethod get-date-from-selected-day :current [previous-date selected-day]
   (timec/to-date (time/date-time (time/year previous-date)
@@ -143,7 +148,8 @@
                               (time/days (time/day-of-week date)))]
     (map #(time/plus start-day
                      (time/days %))
-         (range 1 8))))
+        ;;  (range 1 8)
+         (range 8))))
 
 (defn current-week
   "Returns a list of days for the current week"
@@ -185,7 +191,7 @@
                     (apply dom/tr nil
                            (map (fn [d]
                                   (om/build day-component app {:state {:day d :path path :date date :onChange onChange}})) week)))
-                  (build-weeks date :week-starts-on-sunday? false))))))
+                  (build-weeks date :week-starts-on-sunday? week-starts-on-sunday?))))))
 
 (defn- year-component [app owner]
   (reify
@@ -241,7 +247,7 @@
                                             (om/build-all day-header (weekday-labels week-starts-on-sunday?))))
 
                           ;; datepicker body
-                          (om/build weeks-component app {:state {:path path :date date :onChange onChange}}))))))
+                          (om/build weeks-component app {:state state}))))))
 
 (defn datepicker
   "Datepicker public API

--- a/src/om_widgets/datepicker.cljs
+++ b/src/om_widgets/datepicker.cljs
@@ -9,6 +9,15 @@
 ;; TODO translate
 (defonce days-short ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"])
 
+(defn weekday-labels
+  "Returns the short labels for the days of the week.
+  If week-starts-on-sunday? is true, the week starts on Sunday,
+  otherwise it starts on Monday."
+  [week-starts-on-sunday?]
+  (if week-starts-on-sunday?
+    (concat ["Su"] (butlast days-short))
+    days-short))
+
 (defn- build-previous-month-days [date]
   (let [current-month (time/date-time (time/year date) (time/month date))
         weekday-current-month (time/day-of-week current-month)
@@ -55,7 +64,8 @@
     [...]
   [{:day 1 :month 3 :year 2014 :belongs-to-month :next}] ]
   "
-  [date]
+  [date & {:keys [week-starts-on-sunday?]
+           :or {week-starts-on-sunday? false}}]
   (let [previous-days (build-previous-month-days date)
         currrent-days (build-current-month-days date)
         next-days (build-next-month-days date)
@@ -167,13 +177,15 @@
     om/IDisplayName
     (display-name [_] "DatepickerWeeks")
     om/IRenderState
-    (render-state [this {:keys [date path onChange] :as state}]
+    (render-state [this {:keys [date path onChange week-starts-on-sunday?]
+                         :or {week-starts-on-sunday? false}
+                         :as state}]
       (apply dom/tbody nil
              (map (fn [week]
                     (apply dom/tr nil
                            (map (fn [d]
                                   (om/build day-component app {:state {:day d :path path :date date :onChange onChange}})) week)))
-                  (build-weeks date))))))
+                  (build-weeks date :week-starts-on-sunday? false))))))
 
 (defn- year-component [app owner]
   (reify
@@ -202,7 +214,10 @@
     om/IDisplayName
     (display-name [_] "DatepickerBody")
     om/IRenderState
-    (render-state [this {:keys [path date onChange] :as state}]
+    (render-state [this {:keys [path date onChange
+                                week-starts-on-sunday?]
+                         :or {week-starts-on-sunday? false}
+                         :as state}]
       (dom/div #js {:className "datepicker datepicker-days" :style #js {:display "block"}}
                (dom/table #js {:className "table-condensed"}
                           (dom/thead nil
@@ -223,7 +238,7 @@
                                                           :onClick (fn [e]
                                                                      (om/set-state! owner :date (time/plus date (time/months 1))))} ">"))
                                      (apply dom/tr nil
-                                            (om/build-all day-header days-short)))
+                                            (om/build-all day-header (weekday-labels week-starts-on-sunday?))))
 
                           ;; datepicker body
                           (om/build weeks-component app {:state {:path path :date date :onChange onChange}}))))))
@@ -239,11 +254,14 @@
 
   note: we assume today date if the cursor does not have a date
   "
-  [app path {:keys [id hidden onChange] :or {hidden true}}]
+  [app path {:keys [id hidden onChange week-starts-on-sunday?] 
+             :or {hidden true 
+                  week-starts-on-sunday? false}}]
   (om/build body-component app {:state {:id id
                                         :hidden hidden
                                         :date (if (instance? js/Date (utils/om-get app [path]))
                                                 (time/date-time (utils/om-get app [path]))
                                                 (time/now))
                                         :path path
-                                        :onChange onChange}}))
+                                        :onChange onChange
+                                        :week-starts-on-sunday? week-starts-on-sunday?}}))


### PR DESCRIPTION
Introduce a new option for the datepicker to allow weeks to start on Sunday. Fix typos in the datepicker example and update the state example to include the new inline datepicker with this functionality.